### PR TITLE
Add migration status in uploader check

### DIFF
--- a/src/comotion/dash.py
+++ b/src/comotion/dash.py
@@ -1515,7 +1515,7 @@ def read_and_upload_file_to_dash(
             # Get migration status
             migration = Migration(config)
             print('Migration Status: ' + str(migration.status().full_migration_status))
-            if migration.status().full_migration_status == 'Completed':
+            if migration.status().full_migration_status in ['Completed', 'Complete']:
                 data_model_version = 'v2'
             else:
                 data_model_version = 'v1'

--- a/src/comotion/dash.py
+++ b/src/comotion/dash.py
@@ -1514,8 +1514,9 @@ def read_and_upload_file_to_dash(
 
             # Get migration status
             migration = Migration(config)
-            print('Migration Status: ' + str(migration.status().full_migration_status))
-            if migration.status().full_migration_status in ['Completed', 'Complete']:
+            migration_status = migration.status().full_migration_status
+            print('Migration Status: ' + migration_status)
+            if migration_status in ['Completed', 'Complete']:
                 data_model_version = 'v2'
             else:
                 data_model_version = 'v1'


### PR DESCRIPTION
Patch issue where migration status can show "Complete" or "Completed" when determining data model version in read_and_upload_file_to_dash function.