### PR TITLE
Allow any error message in load meta data

### DIFF
--- a/src/comodash_api_client_lowlevel/models/load_meta_data.py
+++ b/src/comodash_api_client_lowlevel/models/load_meta_data.py
@@ -33,7 +33,7 @@ class LoadMetaData(BaseModel):
     """ # noqa: E501
     load_status: StrictStr = Field(description="Current status of the load.", alias="LoadStatus")
     error_type: Optional[StrictStr] = Field(default=None, description="Type of error if the load status is FAIL.", alias="ErrorType")
-    error_messages: Optional[List[LoadMetaDataErrorMessagesInner]] = Field(default=None, description="Detailed error messages if the load status is FAIL.", alias="ErrorMessages")
+    error_messages: Optional[Any] = Field(default=None, description="Detailed error messages if the load status is FAIL.", alias="ErrorMessages")
     __properties: ClassVar[List[str]] = ["LoadStatus", "ErrorType", "ErrorMessages"]
 
     @field_validator('load_status')
@@ -110,7 +110,7 @@ class LoadMetaData(BaseModel):
         _obj = cls.model_validate({
             "LoadStatus": obj.get("LoadStatus"),
             "ErrorType": obj.get("ErrorType"),
-            "ErrorMessages": [LoadMetaDataErrorMessagesInner.from_dict(_item) for _item in obj.get("ErrorMessages")] if obj.get("ErrorMessages") is not None else None
+            "ErrorMessages": obj.get("ErrorMessages")
         })
         return _obj
 

--- a/src/comotion/cli.py
+++ b/src/comotion/cli.py
@@ -471,7 +471,10 @@ def get_load_info(
     click.echo(load_info.load_status)
     if load_info.load_status == "FAIL":
         for error_message in load_info.error_messages:
-            click.echo(f"{error_message.error_type}:{error_message.error_message}", err=True)
+            try:
+                click.echo(f"{error_message.error_type}:{error_message.error_message}", err=True)
+            except:
+                click.echo(f"{error_message}", err=True)
 
 @dash.command()
 @click.option(

--- a/tests/test_integration_tests.py
+++ b/tests/test_integration_tests.py
@@ -834,8 +834,7 @@ finalising file...
         ]
 
         # Define the expected result/output from the CLI command
-        expected_result = 'FAIL\nmy error type 2:my error message 2\n'
-
+        expected_result = "FAIL\n{'ErrorType': 'my error type 2', 'ErrorMessage': 'my error message 2'}\n"
 
         # Call the generic integration test function with the above parameters
         self._generic_integration_test(


### PR DESCRIPTION
Has been causing issues because of LoadMetaData model when error is returned.  Updated messaging of cli and unit test to match output.